### PR TITLE
0.7 bug fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Fixed using the first block's transform for all data blocks
+
+## Version 0.7.0 - 2025-09-05
 - Added support for reading NeFS versions 0.1.0, 0.2.0, 1.3.0, 1.4.0, 1.5.0, 1.5.1
 - Added support for reading split data and multiple volume archives
 - Added support for reading big-endian NeFS headers

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fixed mistakenly considering certain archives are split
 - Fixed using the first block's transform for all data blocks
 
 ## Version 0.7.0 - 2025-09-05

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## Version 0.7.1 - 2025-09-14
 - Fixed mistakenly considering certain archives are split
 - Fixed using the first block's transform for all data blocks
 - Fixed not being able to find headers in newer F1 games with ability to search entire exe rather than just data section

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Fixed mistakenly considering certain archives are split
 - Fixed using the first block's transform for all data blocks
+- Fixed not being able to find headers in newer F1 games with ability to search entire exe rather than just data section
 
 ## Version 0.7.0 - 2025-09-05
 - Added support for reading NeFS versions 0.1.0, 0.2.0, 1.3.0, 1.4.0, 1.5.0, 1.5.1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
 		<UseArtifactsOutput>true</UseArtifactsOutput>
 
 		<Copyright>Copyright © VictorBush 2021</Copyright>
-		<Version>0.7.0</Version>
+		<Version>0.7.1</Version>
 	</PropertyGroup>
 </Project>

--- a/VictorBush.Ego.NefsEdit/UI/OpenFileForm.Designer.cs
+++ b/VictorBush.Ego.NefsEdit/UI/OpenFileForm.Designer.cs
@@ -38,6 +38,7 @@
             this.label2 = new System.Windows.Forms.Label();
             this.headlessTabPage = new System.Windows.Forms.TabPage();
             this.gameDatRefreshButton = new System.Windows.Forms.Button();
+            this.headlessSearchEntireExeCheckBox = new System.Windows.Forms.CheckBox();
             this.gameDatFilesLabel = new System.Windows.Forms.Label();
             this.gameDatFilesListBox = new System.Windows.Forms.ListBox();
             this.gameExeFileButton = new System.Windows.Forms.Button();
@@ -171,6 +172,7 @@
             // headlessTabPage
             //
             this.headlessTabPage.Controls.Add(this.gameDatRefreshButton);
+            this.headlessTabPage.Controls.Add(this.headlessSearchEntireExeCheckBox);
             this.headlessTabPage.Controls.Add(this.gameDatFilesLabel);
             this.headlessTabPage.Controls.Add(this.gameDatFilesListBox);
             this.headlessTabPage.Controls.Add(this.gameExeFileButton);
@@ -199,6 +201,16 @@
             this.gameDatRefreshButton.Text = "Search";
             this.gameDatRefreshButton.UseVisualStyleBackColor = true;
             this.gameDatRefreshButton.Click += new System.EventHandler(this.GameDatRefreshButton_Click);
+            //
+            // headlessSearchEntireExeCheckBox
+            //
+            this.headlessSearchEntireExeCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.headlessSearchEntireExeCheckBox.Location = new System.Drawing.Point(123, 305);
+            this.headlessSearchEntireExeCheckBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.headlessSearchEntireExeCheckBox.Name = "headlessSearchEntireExeCheckBox";
+            this.headlessSearchEntireExeCheckBox.Size = new System.Drawing.Size(144, 35);
+            this.headlessSearchEntireExeCheckBox.TabIndex = 26;
+            this.headlessSearchEntireExeCheckBox.Text = "Search Entire Exe";
             //
             // gameDatFilesLabel
             //
@@ -538,6 +550,7 @@
         private System.Windows.Forms.Label headlessDataDirLabel;
         private System.Windows.Forms.Label gameDatFilesLabel;
         private System.Windows.Forms.ListBox gameDatFilesListBox;
+        private System.Windows.Forms.CheckBox headlessSearchEntireExeCheckBox;
         private System.Windows.Forms.Button gameDatRefreshButton;
         private System.Windows.Forms.ListBox modeListBox;
         private System.Windows.Forms.TabPage recentTabPage;

--- a/VictorBush.Ego.NefsEdit/UI/OpenFileForm.cs
+++ b/VictorBush.Ego.NefsEdit/UI/OpenFileForm.cs
@@ -89,7 +89,8 @@ internal partial class OpenFileForm : Form
 
 		// Search for headers in the exe
 		using var _ = p.BeginTask(1.0f, "Searching for headers");
-		return await ExeHeaderFinder.FindHeadersAsync(exePath, dataDirectory, p);
+		return await ExeHeaderFinder.FindHeadersAsync(exePath, dataDirectory,
+			this.headlessSearchEntireExeCheckBox.Checked, p);
 	}
 
 	private async void GameDatRefreshButton_Click(Object sender, EventArgs e)

--- a/VictorBush.Ego.NefsLib.Tests/Header/Builder/NefsItemListBuilder130Tests.cs
+++ b/VictorBush.Ego.NefsLib.Tests/Header/Builder/NefsItemListBuilder130Tests.cs
@@ -1,0 +1,68 @@
+// See LICENSE.txt for license information.
+
+using VictorBush.Ego.NefsLib.Header;
+using VictorBush.Ego.NefsLib.Header.Builder;
+using VictorBush.Ego.NefsLib.Header.Version010;
+using VictorBush.Ego.NefsLib.Header.Version130;
+using VictorBush.Ego.NefsLib.IO;
+using VictorBush.Ego.NefsLib.Item;
+using Xunit;
+
+namespace VictorBush.Ego.NefsLib.Tests.Header.Builder;
+
+public class NefsItemListBuilder130Tests
+{
+	[Fact]
+	public void BuiltItem_ItemHasUniqueBlockTransforms_ItemCreated()
+	{
+		const string volumeFilePath = "archive.nefs";
+		const string fileName = "test.file";
+		const uint compressedSize = 10;
+		const uint extractedSize = 20;
+		const long dataStart = 100;
+		const uint flags = (uint)NefsTocEntryFlags010.Transformed;
+
+		var header = new NefsHeader130(new NefsWriterSettings(),
+			new NefsTocHeader130
+			{
+				NumVolumes = 1,
+				BlockSize = extractedSize / 2,
+				AesKey = new AesKeyHexBuffer(new string(Enumerable.Repeat('A', 64).ToArray()))
+			},
+			new NefsHeaderEntryTable010(
+				[new NefsTocEntry010 { Start = dataStart, Size = extractedSize, Flags = flags }]),
+			new NefsHeaderLinkTable010([new NefsTocLink010()]),
+			new NefsHeaderNameTable([fileName]),
+			new NefsHeaderBlockTable010([
+				new NefsTocBlock010 { End = compressedSize / 2, Transformation = 1 },
+				new NefsTocBlock010 { End = compressedSize, Transformation = 4 }
+			]), new NefsHeaderVolumeSizeTable010([new NefsTocVolumeSize010 { Size = 2000 }]),
+			new NefsHeaderVolumeNameStartTable130([new NefsTocVolumeNameStart130 { Start = 0 }]),
+			new NefsHeaderNameTable([volumeFilePath]));
+
+		var builder = new NefsItemListBuilder130(header, NefsLog.GetLogger());
+		var item = builder.BuildItem(0, new NefsItemList(volumeFilePath));
+
+		// File has 2 blocks with different transforms
+		Assert.Equal(compressedSize, item.CompressedSize);
+		Assert.Equal(0, item.DirectoryId.Index);
+		Assert.Equal(extractedSize, item.ExtractedSize);
+		Assert.Equal(fileName, item.FileName);
+		Assert.Equal(0, item.Id.Index);
+		Assert.Equal(NefsItemState.None, item.State);
+		Assert.Equal(NefsItemType.File, item.Type);
+		Assert.Equal(volumeFilePath, item.DataSource.FilePath);
+		Assert.Equal(dataStart, item.DataSource.Offset);
+		Assert.True(item.DataSource.IsTransformed);
+		Assert.Equal(2, item.DataSource.Size.Chunks.Count);
+		Assert.Equal(compressedSize / 2, item.DataSource.Size.Chunks[0].Size);
+		Assert.True(item.DataSource.Size.Chunks[0].Transform.IsLzssCompressed);
+		Assert.Equal(compressedSize / 2, item.DataSource.Size.Chunks[1].Size);
+		Assert.True(item.DataSource.Size.Chunks[1].Transform.IsAesEncrypted);
+		Assert.Equal(extractedSize, item.DataSource.Size.ExtractedSize);
+		Assert.Equal(compressedSize, item.DataSource.Size.TransformedSize);
+		Assert.True(item.Attributes.IsTransformed);
+		Assert.NotNull(item.Transform);
+		Assert.True(item.Transform.IsLzssCompressed);
+	}
+}

--- a/VictorBush.Ego.NefsLib/Header/AesKeyHexBuffer.cs
+++ b/VictorBush.Ego.NefsLib/Header/AesKeyHexBuffer.cs
@@ -5,10 +5,34 @@ using System.Text;
 
 namespace VictorBush.Ego.NefsLib.Header;
 
-[InlineArray(64)]
+[InlineArray(Size)]
 public struct AesKeyHexBuffer
 {
+	/// <summary>
+	/// The size of the buffer in bytes.
+	/// </summary>
+	public const int Size = 0x40;
+
 	private byte element;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AesKeyHexBuffer"/> struct.
+	/// </summary>
+	/// <param name="hexString">A string of hex data.</param>
+	public AesKeyHexBuffer(string hexString)
+	{
+		const string msg = "The hex string must have exactly 64 characters representing hex digits.";
+		if (hexString.Length != Size)
+		{
+			throw new ArgumentException(msg);
+		}
+
+		var bytesEncoded = Encoding.ASCII.GetBytes(hexString, this);
+		if (hexString.Length != bytesEncoded)
+		{
+			throw new ArgumentException(msg);
+		}
+	}
 
 	/// <summary>
 	/// Gets the AES-256 key for this header.

--- a/VictorBush.Ego.NefsLib/Header/Builder/NefsItemListBuilder.cs
+++ b/VictorBush.Ego.NefsLib/Header/Builder/NefsItemListBuilder.cs
@@ -82,6 +82,18 @@ internal abstract class NefsItemListBuilder<T>(T header, ILogger logger) : NefsI
 
 	private NefsVolumeSource[] BuildVolumeSources(string dataFilePath)
 	{
+		var splitSize = Header.SplitSize;
+		if (splitSize != 0 && Header.Volumes.Count > 0)
+		{
+			// Sometimes the split size lies. Even though it's >0, the volume is not split
+			// Seen on RD: Grid PS3 BLES-00256 version
+			var fileSize = new FileInfo(dataFilePath).Length;
+			if (fileSize > Header.Volumes[0].DataOffset)
+			{
+				splitSize = 0;
+			}
+		}
+
 		var volumes = new NefsVolumeSource[Header.Volumes.Count];
 		for (var i = 0; i < volumes.Length; ++i)
 		{
@@ -105,7 +117,7 @@ internal abstract class NefsItemListBuilder<T>(T header, ILogger logger) : NefsI
 				}
 			}
 
-			var volume = new NefsVolumeSource(filePath, headerVolume.DataOffset, Header.SplitSize);
+			var volume = new NefsVolumeSource(filePath, headerVolume.DataOffset, splitSize);
 			volumes[i] = volume;
 		}
 

--- a/VictorBush.Ego.NefsLib/Header/Builder/NefsItemListBuilder.cs
+++ b/VictorBush.Ego.NefsLib/Header/Builder/NefsItemListBuilder.cs
@@ -135,8 +135,8 @@ internal abstract class NefsItemListBuilder<T>(T header, ILogger logger) : NefsI
 			}
 
 			// Determine transform
-			transform ??= GetTransform(block.Transformation);
-			if (transform is null)
+			var chunkTransform = transform ?? GetTransform(block.Transformation);
+			if (chunkTransform is null)
 			{
 				Logger.LogError("Found data chunk with unknown transform {BlockTransformation}; aborting.",
 					block.Transformation);
@@ -146,7 +146,7 @@ internal abstract class NefsItemListBuilder<T>(T header, ILogger logger) : NefsI
 			}
 
 			// Create data chunk info
-			var chunk = new NefsDataChunk(size, cumulativeSize, transform) { Checksum = block.Checksum };
+			var chunk = new NefsDataChunk(size, cumulativeSize, chunkTransform) { Checksum = block.Checksum };
 			chunks.Add(chunk);
 		}
 

--- a/VictorBush.Ego.NefsLib/IO/INefsExeHeaderFinder.cs
+++ b/VictorBush.Ego.NefsLib/IO/INefsExeHeaderFinder.cs
@@ -14,5 +14,6 @@ public interface INefsExeHeaderFinder
 	/// Find headers within the exe file.
 	/// </summary>
 	/// <returns>The archive source based on the found headers.</returns>
-	Task<List<HeadlessSource>> FindHeadersAsync(string exePath, string dataFileDir, NefsProgress p);
+	Task<List<HeadlessSource>> FindHeadersAsync(string exePath, string dataFileDir, bool searchEntireExe,
+		NefsProgress p);
 }

--- a/VictorBush.Ego.NefsLib/IO/NefsWriter.cs
+++ b/VictorBush.Ego.NefsLib/IO/NefsWriter.cs
@@ -245,8 +245,9 @@ public class NefsWriter : INefsWriter
 		}
 
 		// Prepare streams
+		var splitSize = sourceItems.Volumes.Count > 0 ? sourceItems.Volumes[0].SplitSize : sourceHeader.SplitSize;
 		var dataOffset = headerBuilder.ComputeDataOffset(sourceHeader, items);
-		var volumeSource = new NefsVolumeSource(filePath, dataOffset, sourceHeader.SplitSize);
+		var volumeSource = new NefsVolumeSource(filePath, dataOffset, splitSize);
 		const FileMode fileMode = FileMode.OpenOrCreate;
 		const FileAccess fileAccess = FileAccess.ReadWrite;
 		const FileShare fileShare = FileShare.None;


### PR DESCRIPTION
- Fix using the first block's transform for all data blocks
- Fix mistakenly considering certain archives are split
- Fix not being able to find headers in new F1 games
- Improve header read speed